### PR TITLE
Revert "Fix typo in aacs updater"

### DIFF
--- a/aacs-update.service
+++ b/aacs-update.service
@@ -3,7 +3,7 @@ Description=Download and install AACS KEYDB.cfg
 
 [Service]
 Type=simple
-ExecStart=/opt/aacs_updater/aacs_updater.sh
+ExecStart=/opt/aacs_updater/aacs-updater.sh
 
 [Install]
 Alias=aacs.service


### PR DESCRIPTION
Reverts RiderExMachina/aacs-update#1

No actual typo, this actually breaks the systemd timer